### PR TITLE
Learn tag

### DIFF
--- a/build/BBTemplate/class.tmpl
+++ b/build/BBTemplate/class.tmpl
@@ -86,6 +86,24 @@
 				vertical-align: top;
 				background-color: #FCD8B9;
 			}
+			
+			table.learnTable {
+				border-width: 1px;
+				border-style: solid;
+				border-color: #ccc;
+				padding: 5px;
+				vertical-align: top;
+				margin: 5px;
+				margin-bottom:15px;
+				width : 90%;
+				background-color: #99FFCC;
+			}
+			
+			td.learnTd {
+				color: #484848;
+				vertical-align: top;
+				background-color: #99FFCC;
+			}
 
 		</style>
 	  
@@ -93,6 +111,14 @@
 		<script src="server.js"></script>
 	</head>
 	
+
+<!-- ============================== description ============================ -->
+	<p>
+		<if test="data.classDesc">
+			{+resolveLinks(data.classDesc)+}
+		</if>
+	</p>
+
 <!-- ============================== Beta Tag ============================ -->
 	<if test="data.betaTag">
 		<table class="betaTable">
@@ -112,12 +138,23 @@
 			 </tr>
 		</table>
 	</if>
-<!-- ============================== description ============================ -->
-	<p>
-		<if test="data.classDesc">
-			{+resolveLinks(data.classDesc)+}
-		</if>
-	</p>
+
+
+<!-- ============================== Learning Resources ============================ -->
+	<if test="data.learnTag">
+		<table class="learnTable">
+			 <tr>
+				<td class="learnTd">
+				   <div class="title">Learning Resources:</div>
+				   <for each="item" in="data.learnTag">
+					{!output+="<a href=" + item.name + ">" + item.type + "</a>";!}
+					{+item.desc+}
+				   </for>
+				</td>
+
+			 </tr>
+		</table>
+	</if>
 	
 <!-- ============================== Support Platforms ============================ -->
 	{!var allChildren =[]!}

--- a/build/BBTemplate/class.tmpl
+++ b/build/BBTemplate/class.tmpl
@@ -143,16 +143,15 @@
 <!-- ============================== Learning Resources ============================ -->
 	<if test="data.learnTag">
 		<table class="learnTable">
-			 <tr>
-				<td class="learnTd">
-				   <div class="title">Learning Resources:</div>
-				   <for each="item" in="data.learnTag">
-					{!output+="<a href=" + item.name + ">" + item.type + "</a>";!}
-					{+item.desc+}
-				   </for>
-				</td>
-
-			 </tr>
+			<div class="title">Learning Resources:</div>
+			<for each="item" in="data.learnTag">
+				<tr>
+					<td class="learnTd">
+						{!output+="<a href=" + item.name + ">" + item.type + "</a>";!}
+						{+item.desc+}
+					</td>
+				</tr>
+			</for>
 		</table>
 	</if>
 	

--- a/build/BBTemplate/publish.js
+++ b/build/BBTemplate/publish.js
@@ -285,17 +285,7 @@ function resolveLinks(str, from) {
 			return "<image src=\""+publish.conf.imagesDir + fileName+"\">";
 		}
 	);
-
-	//str = str.replace(/\{@learns ([^} ]+) ?\}/gi,
-	//	function(match, symbolName) {
-	//		
-	//		var linkAddress; //have to retrieve this somehow
-	//		var linkName; //have to retrieve this somehow
-	//		
-	//		return "<a href=\"" + linkAddress + ">" + linkName +"\"</a>";
-	//	}
-	//);
-
+	
 	return str;
 }
 

--- a/build/BBTemplate/publish.js
+++ b/build/BBTemplate/publish.js
@@ -284,8 +284,18 @@ function resolveLinks(str, from) {
 			}catch(e){}
 			return "<image src=\""+publish.conf.imagesDir + fileName+"\">";
 		}
-	);	
-	
+	);
+
+	//str = str.replace(/\{@learns ([^} ]+) ?\}/gi,
+	//	function(match, symbolName) {
+	//		
+	//		var linkAddress; //have to retrieve this somehow
+	//		var linkName; //have to retrieve this somehow
+	//		
+	//		return "<a href=\"" + linkAddress + ">" + linkName +"\"</a>";
+	//	}
+	//);
+
 	return str;
 }
 

--- a/build/bbPlugin.js
+++ b/build/bbPlugin.js
@@ -33,7 +33,7 @@ JSDOC.PluginManager.registerPlugin(
                 var betaTag = symbol.comment.getTag("beta");
                 var paramCallbacks = symbol.comment.tags.filter(function($){return $.isCallback && $.title == "param"});
                 var fieldCBs = symbol.comment.tags.filter(function($){return $.isCallback && $.title == "field"});
-		var learnTag = symbol.comment.getTag("learn");
+		var learnTag = symbol.comment.getTag("learns");
                 
                 //If its a class/namespace
                 if((symbol.is("CONSTRUCTOR") || symbol.isNamespace) && !(symbol.alias == "_global_")){
@@ -55,7 +55,7 @@ JSDOC.PluginManager.registerPlugin(
                     }
 		    
 		    if(learnTag.length) {
-                        symbol.betaTag = learnTag;
+                        symbol.learnTag = learnTag;
                     }
                 }else{ //Its a property or method
                     if(readOnly.length){
@@ -64,11 +64,7 @@ JSDOC.PluginManager.registerPlugin(
                     if( uri.length){
                         symbol.uri = uri;
                     }
-                    
-		    if(learnTag.length) {
-                        symbol.betaTag = learnTag;
-                    }
-		    
+                
                     //Mark all parameters as callback based on their tags
                     if(paramCallbacks.length){
                         for(var i=0;i<paramCallbacks.length;i++){
@@ -130,6 +126,9 @@ JSDOC.PluginManager.registerPlugin(
                     docTag.title = "param";
                     docTag.isCallback = true;
                 }
+		if (docTag.title == "learns"){
+		    docTag.desc = docTag.nibbleName(docTag.desc);
+		}
             }           
         }
     }

--- a/build/bbPlugin.js
+++ b/build/bbPlugin.js
@@ -33,6 +33,7 @@ JSDOC.PluginManager.registerPlugin(
                 var betaTag = symbol.comment.getTag("beta");
                 var paramCallbacks = symbol.comment.tags.filter(function($){return $.isCallback && $.title == "param"});
                 var fieldCBs = symbol.comment.tags.filter(function($){return $.isCallback && $.title == "field"});
+		var learnTag = symbol.comment.getTag("learn");
                 
                 //If its a class/namespace
                 if((symbol.is("CONSTRUCTOR") || symbol.isNamespace) && !(symbol.alias == "_global_")){
@@ -52,6 +53,10 @@ JSDOC.PluginManager.registerPlugin(
 		    if(betaTag.length) {
                         symbol.betaTag = betaTag;
                     }
+		    
+		    if(learnTag.length) {
+                        symbol.betaTag = learnTag;
+                    }
                 }else{ //Its a property or method
                     if(readOnly.length){
                         symbol.readOnly = readOnly;
@@ -60,6 +65,10 @@ JSDOC.PluginManager.registerPlugin(
                         symbol.uri = uri;
                     }
                     
+		    if(learnTag.length) {
+                        symbol.betaTag = learnTag;
+                    }
+		    
                     //Mark all parameters as callback based on their tags
                     if(paramCallbacks.length){
                         for(var i=0;i<paramCallbacks.length;i++){


### PR DESCRIPTION
This feature branch adds support for a learn tag. 

The learn tag is supposed to notify the developer of learning resources available for the specific API that they are viewing. It would be added in the following manner: 

/**
- @namespace The Utils object provides useful utility functions and properties.  
- @toc {Utilities} Utils
- @featureID blackberry.utils
- @learns {W3C Schools} http://www.w3schools.com/ This link redirects to W3C Schools, where they offer free tutorials in all web development technologies.
  */

I will send a picture of what the addition of the tag to an API would look like, as I seem unable to figure how to add a picture to this discussion. 
