### PR TITLE
@constructedBy attribute

### DIFF
--- a/build/BBTemplate/class.tmpl
+++ b/build/BBTemplate/class.tmpl
@@ -454,15 +454,21 @@
     {+ResetIndex()+}
     <if test="data.constructedBy">
         <for each="constructedBy" in="data.constructedBy">
-            <h2><a name="constructedBy{+GenerateIndex()+}"> </a>{+constructedBy.type+}</h2>
-            <hr style="margin-bottom:15px;"/>
-			<div class="title">Description</div>
-			&nbsp;{+resolveLinks(constructedBy.desc)+}
-            <table class="scriptTable">				
-                <tr><td class="scriptTd">
-                <pre>{+constructedBy.example+}</pre>
-                </td></tr>
-            </table>
+            <if test="constructedBy.type">
+                <h2><a name="constructedBy{+GenerateIndex()+}"> </a>{+constructedBy.type+}</h2>
+                <hr style="margin-bottom:15px;"/>
+                <if test="constructedBy.desc">
+                    <div class="title">Description</div>
+                    &nbsp;{+resolveLinks(constructedBy.desc)+}
+                </if>
+                <if test="constructedBy.example">
+                    <table class="scriptTable">
+                        <tr><td class="scriptTd">
+                        <pre>{+constructedBy.example+}</pre>
+                        </td></tr>
+                    </table>
+                 </if>
+             </if>
         </for>
     </if>
 <!-- ============================== Function details ========================= -->		

--- a/build/BBTemplate/class.tmpl
+++ b/build/BBTemplate/class.tmpl
@@ -245,11 +245,21 @@
 
 <!-- ============================== Constructor Summary ========================= -->
 <!-- NEW: BETA -->
-	<if test="!data.isBuiltin() && data.is('CONSTRUCTOR')">
+	<if test="(!data.isBuiltin() && data.is('CONSTRUCTOR')) || data.constructedBy">
 		<h1>Constructor</h1>
-		<ul class="ulNoTopMargin">
-			<li>{+new Link().toSymbol(data.alias).withText(data.name.replace(/\^\d+$/, ''))+}</li>
-		</ul>
+        <ul class="ulNoTopMargin">
+            <if test="!data.noConstructor">
+                <li>{+new Link().toSymbol(data.alias).withText(data.name.replace(/\^\d+$/, ''))+}</li>
+            </if>
+            <if test="data.constructedBy">
+                {+ResetIndex()+}
+                <for each="constructedBy" in="data.constructedBy">
+                    <if test="constructedBy.type">
+                        <li><a href="#constructedBy{+GenerateIndex()+}">{+constructedBy.type+}</a></li>
+                    </if>
+                </for>
+            </if>
+        </ul>
 	</if>
 
 <!-- ============================== Function Summary  ==================== -->
@@ -344,9 +354,9 @@
 	
 <!-- ============================== Constructor Details ========================= -->
 <!-- NEW: BETA -->
-	<if test="!data.isBuiltin() && data.is('CONSTRUCTOR')">
+	<if test="!data.isBuiltin() && data.is('CONSTRUCTOR') && !data.noConstructor">
 		<div x-ww-support="{+data.supportTag+}">
-			<h2><a name="{ +Link.symbolNameToLinkName(data)+}"> </a>{+data.alias+}</h2>
+			<h2><a name="{+Link.symbolNameToLinkName(data)+}"> </a>{+data.alias+}</h2>
 			<hr style="margin-bottom:15px;"/>
 		
 			<table class="scriptTable">
@@ -441,6 +451,20 @@
 			</if>
 		</div>
 	</if>
+    {+ResetIndex()+}
+    <if test="data.constructedBy">
+        <for each="constructedBy" in="data.constructedBy">
+            <h2><a name="constructedBy{+GenerateIndex()+}"> </a>{+constructedBy.type+}</h2>
+            <hr style="margin-bottom:15px;"/>
+			<div class="title">Description</div>
+			&nbsp;{+resolveLinks(constructedBy.desc)+}
+            <table class="scriptTable">				
+                <tr><td class="scriptTd">
+                <pre>{+constructedBy.example+}</pre>
+                </td></tr>
+            </table>
+        </for>
+    </if>
 <!-- ============================== Function details ========================= -->		
 	<if test="defined(ownMethods) && ownMethods.length">
 		<for each="member" in="ownMethods">

--- a/build/bbPlugin.js
+++ b/build/bbPlugin.js
@@ -20,7 +20,7 @@
  * Put this file in <JSDoc dir>\app\plugins\ and it will be used whenever JSDoc is run.
  */
 
-
+/** Generate Incrementing Numbers for use in templates **/
 var generatedindex = 0;
 
 function ResetIndex()
@@ -34,6 +34,7 @@ function GenerateIndex()
     return generatedindex++;
 }
 
+/** Fetch and remove additional { foo } parameters from a string **/
 function GetType(src)
 {
     var type = null;
@@ -69,7 +70,7 @@ JSDOC.PluginManager.registerPlugin(
                 var learnTag = symbol.comment.getTag("learns");
 				var squareAccessor = symbol.comment.getTag("squareAccessor");
                 var constructorTag = symbol.comment.getTag("constructor");
-                var constructedBy = symbol.comment.tags.filter(function($){return $.title=="constructedBy" && !!$.type}); 
+                var constructedBy = symbol.comment.tags.filter(function($){return $.title=="constructedBy" && $.type}); 
                 
 				//If its a class/namespace
 				if((symbol.is("CONSTRUCTOR") || symbol.isNamespace) && !(symbol.alias == "_global_")){


### PR DESCRIPTION
Added @constructedBy to document how objects are created that do not use the regular constructor.
For example:

HTMLAudioElement is created by new Audio()
HTMLVideoElement is created by document.createElement("video");

if a @constructedBy is specified, and no @constructor is present, the default constructor is not generated.
if both @constructedBy and @constructor are present. Both are generated

/**
- this is a MyClass description
- @class
- @constructor
- @param {Number} [foo] foo is a constructor param
- @constructedBy {document.createElement("MyClass")} {This is a description}
- // this is an example of how to create a new instance of MyClass
- var instance = document.createElement("MyClass");
  */

MyClass = function(foo) { }
