### PR TITLE
Permissions Tag

### DIFF
--- a/build/BBTemplate/class.tmpl
+++ b/build/BBTemplate/class.tmpl
@@ -240,47 +240,62 @@
 <!-- ============================== Configuration Settings  ============================ -->	
 	<br/>
 	<div class="title">Configuration Document Settings</div>
-	To use <u>all</u> of the API described for this object, you must ensure the following settings are in your configuration document:    	
-    
-    <table class="scriptTable">
-        <tr><th>Feature Elements</th></tr>
-        <if test="data.featureID">
-            <tr><td class="scriptTd">
-    		  You must declare the feature element(s) below in your configuration document:
-    		</td></tr><br>
-    		
-    			<for each="item" in="data.featureID">
-    				<tr><td class="scriptTd"> 
-    						&lt;feature id="{+item.desc+}" /&gt;
-    						<br>
-    				</td></tr>
-    			</for>		
-    	<else/>
-    	    <tr><td class="scriptTd">
-    		  This API does not require a &lt;feature&gt; element to be declared in the configuration document of your BlackBerry WebWorks Application.
-            </td></tr><br/>
-    	</if>
+		To use <u>all</u> of the API described for this object, you must ensure the following settings are in your configuration document:    	
+	
+	<table class="scriptTable">
+		<tr><th>Feature Elements</th></tr>
+		<if test="data.featureID">
+			<tr><td class="scriptTd">
+			You must declare the feature element(s) below in your configuration document:
+		</td></tr><br>
+			<for each="item" in="data.featureID">
+				<tr><td class="scriptTd"> 
+				&lt;feature id="{+item.desc+}" /&gt;
+				<br>
+				</td></tr>
+			</for>		
+		<else/>
+			<tr><td class="scriptTd">
+			This API does not require a &lt;feature&gt; element to be declared in the configuration document of your BlackBerry WebWorks Application.
+			</td></tr><br/>
+		</if>
 	</table>
 	
-    <table class="scriptTable">
-        <tr><th>Permission Elements (Only For Playbook)</th></tr>
-        <if test="data.permission">
-            <tr><td class="scriptTd">
-              You must declare the permission element(s) below in your configuration document:
-            </td></tr><br>
-            
-                <for each="item" in="data.permission">
-                    <tr><td class="scriptTd"> 
-                            &lt;permission="{+item.desc+}" /&gt;
-                            <br>
-                    </td></tr>
-                </for>      
-        <else/>
-            <tr><td class="scriptTd">
-              This API does not require a &lt;permission&gt; element to be declared in the configuration document of your BlackBerry WebWorks Application.
-            </td></tr><br/>
-        </if>
-    </table>
+	<div x-ww-support="pb1.0">	
+		<table class="scriptTable">
+		<tr><th>Permission Elements (Only For Playbook)</th></tr>
+		<if test="data.permission">
+			{! var mandatory = data.permission.filter(function($){return !$.isOptional}).sort(makeSortby("name"));!}
+			{! var optional = data.permission.filter(function($){return $.isOptional}).sort(makeSortby("name"));!}
+			<tr><td class="scriptTd">
+			You must declare the permission element(s) below in your configuration document:
+			</td></tr><br>
+			
+			<for each="item" in="mandatory">
+				<tr><td class="scriptTd">
+				- &lt;permission="{+item.name+}" /&gt; {+item.desc+}
+				<br>
+				</td></tr>
+			</for>
+			
+			<tr><td class="scriptTd">
+			</br>
+			<i><b>Note:</b> Declaring the permission element(s) below in your configuration document is optional.</i></br>
+			</td></tr><br>
+			
+			<for each="item" in="optional">
+				<tr><td class="scriptTd">
+				- &lt;permission="{+item.name+}" /&gt; {+item.desc+}
+				<br>
+				</td></tr>
+			</for>
+		<else/>
+			<tr><td class="scriptTd">
+			This API does not require a &lt;permission&gt; element to be declared in the configuration document of your BlackBerry WebWorks Application.
+			</td></tr><br/>
+		</if>
+		</table>
+	</div>
 
 <!-- ============================== Constructor Summary ========================= -->
 	<if test="(!data.isBuiltin() && data.is('CONSTRUCTOR')) || data.constructedBy">

--- a/build/BBTemplate/publish.js
+++ b/build/BBTemplate/publish.js
@@ -153,8 +153,10 @@ function makeSortby(attribute) {
 	return function(a, b) {
 		try{
 		if (a[attribute] != undefined && b[attribute] != undefined) {
-			a = a[attribute].toLowerCase();
-			b = b[attribute].toLowerCase();
+			if (a[attribute].toLowerCase && b[attribute].toLowerCase) {
+				a = a[attribute].toLowerCase();
+				b = b[attribute].toLowerCase();
+			}
 			if (a < b) return -1;
 			if (a > b) return 1;
 			return 0;

--- a/cookbook/blackberry_example_class.js
+++ b/cookbook/blackberry_example_class.js
@@ -19,6 +19,11 @@
  * @toc {OtherSamples} Example Class
  * @featureID blackberry.exampleClass
  * @beta This is how to use the beta tag
+ * @permission some_id_permission Descriptive text for this permission, which is required for this example class
+ * @permission [some_optional_id_permission] Descriptive text for this permission, which is optional for this example class
+ * @permission [some_optional_id_permission2] Descriptive text for some_optional_id_permission2
+ * @permission some_id_permission2 Descriptive text for some_id_permission2
+ * @permission some_id_permission3 Descriptive text for some_id_permission3
 */
 blackberry.exampleClass = function() {};
 


### PR DESCRIPTION
Added support for @permission tag, which allows addition of permissions to config.xml, with the possibility of adding descriptive text.
This also provides support for optional permissions, as it could be a possible use case.
