### PR TITLE
fix for blackberry.system.hasPermission method

### DIFF
--- a/api/blackberry_system.js
+++ b/api/blackberry_system.js
@@ -74,7 +74,7 @@ blackberry.system ={
 		 * @BB50+
 		 * @PB10
 		 */
-		hasPermissions : function(module){},
+		hasPermission : function(module){},
 		
 		/**
 		 * @description Returns whether USB MassStorage mode is active.


### PR DESCRIPTION
hasPermissions here:
https://github.com/blackberry/WebWorks/blob/master/api/system/src/blackberry/system/SystemNamespace.java

hasPermission here:
https://github.com/blackberry/WebWorks/blob/master/api/system/src/blackberry/system/SystemNamespace.java#L40

I would assume that this is a bug in the docs.
