### PR TITLE
The bb.io read from HTML5 FileySystem example does not work.

### DIFF
--- a/api/blackberry_io.js
+++ b/api/blackberry_io.js
@@ -32,7 +32,7 @@
  *              // in order to access the shared folder,
  *              // config.xml must declare the "access_shared" permission
  *              // reference file by absolute path since file system is un-sandboxed
- *              fs.root.getFile(blackberry.io.sharedFolder + '/documents/log.txt', {},
+ *              fs.root.getFile(blackberry.io.sharedFolder + '/Documents/log.txt', {create: true},
  *                  function (fileEntry) {
  *                      fileEntry.file(function (file) {
  *                          var reader = new FileReader();


### PR DESCRIPTION
Ref: https://developer.blackberry.com/html5/apis/blackberry.io.html
- The file may not exist, so {creat: true} should be in there.
- `documents` folder should be capitalized.

Note: Let me know if I am mistaken about `Documents`, but I understand it _is_ capitalized, and the file system is case sensitive.
