### PR TITLE
Correct BB5+ event example

### DIFF
--- a/api/blackberry_bbm_platform.js
+++ b/api/blackberry_bbm_platform.js
@@ -97,7 +97,7 @@ blackberry.bbm.platform = {
      * &lt;script type="text/javascript"&gt;
      * 
      * // Create callback invoked when access changes
-     * blackberry.event.addEventListner("onaccesschanged", accessChangedCallback);
+     * blackberry.bbm.platform.onaccesschanged = accessChangedCallback;
      * 
      * function accessChangedCallback(accessible, status) {
      *     if  (status == "allowed") {


### PR DESCRIPTION
I am not 100% sure this is right, but in my testing today it seems that on the pre BB10 webworks, event listeners have to be set by assigning a function to the relevant property. This seems to have been confused throughout the documentation, this just happens to be the bit that I was trying to get working today.
