### PR TITLE
Adding documentation for the ID returning form the addItem callback

### DIFF
--- a/api/blackberry_ui_contextmenu.js
+++ b/api/blackberry_ui_contextmenu.js
@@ -97,7 +97,8 @@ blackberry.ui.contextmenu = {
  * @param {String} action.actionId A property that uniquely defines the action to be added to the context menu.
  * @param {String} action.label A string that will be displayed to the user describing the custom context to be performed. ie: Edit
  * @param {String} action.icon A path to the an image to display in the context menu
- * @callback {Function} callback A function which runs when the menu item action is executed
+ * @param {Function} callback(Id) A function which runs when the menu item action is executed
+ * @param {String} callback.Id The returned Id of a custom context value that this action was triggered on.
  * @BB10X
  * @RIPPLE
  * @example


### PR DESCRIPTION
provided by the user. This supports custom contexts returning the Id
